### PR TITLE
ci: set static claat version

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
     inputs:
       command: "custom"
       customCommand: "install"
-      arguments: "github.com/googlecodelabs/tools/claat@latest"
+      arguments: "github.com/googlecodelabs/tools/claat@v0.0.0-20200918190358-3cc6629c4d3d"
 
   - task: Npm@1
     displayName: "Build: Restore NPM"


### PR DESCRIPTION
`latest` was failing to install so this reverts back to a working version.

```shell
PS C:\code> go install github.com/googlecodelabs/tools/claat@latest
go install github.com/googlecodelabs/tools/claat@latest: github.com/googlecodelabs/tools/claat@v0.0.0-20210610195942-369125588564
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```

I have raised an issue with codelabs/tools for the meantime: https://github.com/googlecodelabs/tools/issues/582